### PR TITLE
Present predictions as prometheus metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM rancher/opni-python-base:3.8
+EXPOSE 8000
 
 COPY ./requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 34,
+  "id": 38,
   "links": [],
   "panels": [
     {
@@ -25,7 +25,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "max": 100,
           "min": 0,
@@ -65,7 +64,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "expr": "(1- (avg(irate(node_cpu_seconds_total{mode=\"idle\"}[5m])))) * 100",
@@ -84,7 +83,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "max": 100,
           "min": 0,
@@ -124,7 +122,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "expr": "100 * (1 - sum(node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes))",
@@ -143,7 +141,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "max": 100,
           "min": 0,
@@ -183,7 +180,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "expr": "(sum(node_filesystem_size_bytes{device!~\"rootfs|HarddiskVolume.+\"})- sum(node_filesystem_free_bytes{device!~\"rootfs|HarddiskVolume.+\"})) / sum(node_filesystem_size_bytes{device!~\"rootfs|HarddiskVolume.+\"}) * 100",
@@ -203,7 +200,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -258,7 +254,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "expr": "sum(irate({__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\",mode!=\"idle\"}[5m]))",
@@ -280,7 +276,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -335,7 +330,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "expr": "sum(kube_node_status_allocatable_cpu_cores{})",
@@ -358,7 +353,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -413,7 +407,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "expr": "sum({__name__=~\"node_memory_MemTotal_bytes|windows_cs_physical_memory_bytes\"}) -sum({__name__=~\"node_memory_MemAvailable_bytes|windows_os_physical_memory_free_bytes\"})",
@@ -436,7 +430,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -491,7 +484,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "expr": "sum (kube_node_status_allocatable_memory_bytes{})",
@@ -514,7 +507,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -569,7 +561,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "expr": "(sum(node_filesystem_size_bytes{device!~\"rootfs|HarddiskVolume.+\"}) - sum(node_filesystem_free_bytes{device!~\"rootfs|HarddiskVolume.+\"}) OR on() vector(0)) + (sum(windows_logical_disk_size_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}) - sum(windows_logical_disk_free_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}) OR on() vector(0))",
@@ -592,7 +584,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -647,7 +638,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "expr": "(sum(node_filesystem_size_bytes{device!~\"rootfs|HarddiskVolume.+\"}) OR on() vector(0)) + (sum(windows_logical_disk_size_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}) OR on() vector(0))",
@@ -663,7 +654,7 @@
       "type": "stat"
     },
     {
-      "datasource": "Elasticsearch",
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -775,7 +766,7 @@
         "x": 0,
         "y": 7
       },
-      "id": 2,
+      "id": 20,
       "options": {
         "graph": {},
         "legend": {
@@ -790,10 +781,9 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "alias": "CpuUsage",
+          "alias": "",
           "bucketAggs": [
             {
-              "field": "timestamp",
               "id": "2",
               "settings": {
                 "interval": "auto"
@@ -801,65 +791,35 @@
               "type": "date_histogram"
             }
           ],
-          "hide": false,
+          "exemplar": true,
+          "expr": "cpu_usage{value_type=\"y\"}",
+          "interval": "",
+          "legendFormat": "CPUUsage",
           "metrics": [
             {
-              "field": "y",
               "id": "1",
-              "type": "avg"
+              "type": "count"
             }
           ],
-          "query": "metric_name:cpu_usage",
+          "query": "",
           "refId": "A",
           "timeField": "timestamp"
         },
         {
-          "alias": "LowerBound",
-          "bucketAggs": [
-            {
-              "field": "timestamp",
-              "id": "2",
-              "settings": {
-                "interval": "auto"
-              },
-              "type": "date_histogram"
-            }
-          ],
+          "exemplar": true,
+          "expr": "cpu_usage{value_type=\"yhat_upper\"}",
           "hide": false,
-          "metrics": [
-            {
-              "field": "yhat_lower",
-              "id": "1",
-              "type": "avg"
-            }
-          ],
-          "query": "metric_name:cpu_usage",
-          "refId": "B",
-          "timeField": "timestamp"
+          "interval": "",
+          "legendFormat": "UpperBound",
+          "refId": "B"
         },
         {
-          "alias": "UpperBound",
-          "bucketAggs": [
-            {
-              "field": "timestamp",
-              "id": "2",
-              "settings": {
-                "interval": "auto"
-              },
-              "type": "date_histogram"
-            }
-          ],
+          "exemplar": true,
+          "expr": "cpu_usage{value_type=\"yhat_lower\"}",
           "hide": false,
-          "metrics": [
-            {
-              "field": "yhat_upper",
-              "id": "1",
-              "type": "avg"
-            }
-          ],
-          "query": "metric_name:cpu_usage",
-          "refId": "C",
-          "timeField": "timestamp"
+          "interval": "",
+          "legendFormat": "LowerBound",
+          "refId": "C"
         }
       ],
       "timeFrom": null,
@@ -868,7 +828,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Elasticsearch",
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -980,7 +940,7 @@
         "x": 8,
         "y": 7
       },
-      "id": 4,
+      "id": 21,
       "options": {
         "graph": {},
         "legend": {
@@ -995,7 +955,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "alias": "MemoryUsage",
+          "alias": "",
           "bucketAggs": [
             {
               "id": "2",
@@ -1005,69 +965,42 @@
               "type": "date_histogram"
             }
           ],
+          "exemplar": true,
+          "expr": "memory_usage{value_type=\"y\"}",
+          "interval": "",
+          "legendFormat": "MemoryUsage",
           "metrics": [
             {
-              "field": "y",
               "id": "1",
-              "type": "avg"
+              "type": "count"
             }
           ],
-          "query": "metric_name:memory_usage",
+          "query": "",
           "refId": "A",
           "timeField": "timestamp"
         },
         {
-          "alias": "LowerBound",
-          "bucketAggs": [
-            {
-              "id": "2",
-              "settings": {
-                "interval": "auto"
-              },
-              "type": "date_histogram"
-            }
-          ],
+          "exemplar": true,
+          "expr": "memory_usage{value_type=\"yhat_upper\"}",
           "hide": false,
-          "metrics": [
-            {
-              "field": "yhat_lower",
-              "id": "1",
-              "type": "avg"
-            }
-          ],
-          "query": "metric_name:memory_usage",
-          "refId": "B",
-          "timeField": "timestamp"
+          "interval": "",
+          "legendFormat": "UpperBound",
+          "refId": "B"
         },
         {
-          "alias": "UpperBound",
-          "bucketAggs": [
-            {
-              "id": "2",
-              "settings": {
-                "interval": "auto"
-              },
-              "type": "date_histogram"
-            }
-          ],
+          "exemplar": true,
+          "expr": "memory_usage{value_type=\"yhat_lower\"}",
           "hide": false,
-          "metrics": [
-            {
-              "field": "yhat_upper",
-              "id": "1",
-              "type": "avg"
-            }
-          ],
-          "query": "metric_name:memory_usage",
-          "refId": "C",
-          "timeField": "timestamp"
+          "interval": "",
+          "legendFormat": "LowerBound",
+          "refId": "C"
         }
       ],
       "title": "Memory Usage",
       "type": "timeseries"
     },
     {
-      "datasource": "Elasticsearch",
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1179,7 +1112,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "alias": "DiskUsage",
+          "alias": "",
           "bucketAggs": [
             {
               "id": "2",
@@ -1189,39 +1122,27 @@
               "type": "date_histogram"
             }
           ],
+          "exemplar": true,
+          "expr": "disk_usage{value_type=\"y\"}",
+          "interval": "",
+          "legendFormat": "DiskUsage",
           "metrics": [
             {
-              "field": "y",
               "id": "1",
-              "type": "avg"
+              "type": "count"
             }
           ],
-          "query": "metric_name:disk_usage",
+          "query": "",
           "refId": "A",
           "timeField": "timestamp"
         },
         {
-          "alias": "UpperBound",
-          "bucketAggs": [
-            {
-              "id": "2",
-              "settings": {
-                "interval": "auto"
-              },
-              "type": "date_histogram"
-            }
-          ],
+          "exemplar": true,
+          "expr": "disk_usage{value_type=\"yhat_upper\"}",
           "hide": false,
-          "metrics": [
-            {
-              "field": "yhat_upper",
-              "id": "1",
-              "type": "avg"
-            }
-          ],
-          "query": "metric_name:disk_usage",
-          "refId": "B",
-          "timeField": "timestamp"
+          "interval": "",
+          "legendFormat": "UpperBound",
+          "refId": "B"
         }
       ],
       "title": "Disk Usage",
@@ -1423,7 +1344,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "alias": "",
@@ -1692,7 +1613,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "alias": "",
@@ -1960,7 +1881,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "7.5.8",
       "targets": [
         {
           "alias": "",
@@ -2060,5 +1981,5 @@
   "timezone": "",
   "title": "MetricAnomaly",
   "uid": "8iPQXA4nk",
-  "version": 42
+  "version": 2
 }

--- a/metric-forecasting/metric_streaming.py
+++ b/metric-forecasting/metric_streaming.py
@@ -76,6 +76,8 @@ PROMETHEUS_CUSTOM_QUERIES = {
 COLUMNS_LIST = [
     'is_anomaly',
     'alert_score',
+    'alert_len',
+    'alert_id'
     'is_alert',
     'y',
     'yhat',

--- a/metric-forecasting/metric_streaming.py
+++ b/metric-forecasting/metric_streaming.py
@@ -85,7 +85,8 @@ COLUMNS_LIST = [
 
 @app.on_event("startup")
 async def startup_event():
-    for metric_name in PROMETHEUS_CUSTOM_QUERIES:
+    logger.info("loading history on webserver startup")
+    for metric_name in PROMETHEUS_CUSTOM_QUERIES.keys():
         MAD_DICT[metric_name] = MetricAnomalyDetector(metric_name)
         GAUGE_DICT[metric_name] = Gauge(metric_name, metric_name, ['value_type'])
         await load_history_data(metric_name, MAD_DICT[metric_name])
@@ -93,11 +94,24 @@ async def startup_event():
 @app.get("/")
 @app.get("/metrics")
 async def get_metrics():
-    for metric_name, query in PROMETHEUS_CUSTOM_QUERIES:
+    for metric_name, query in PROMETHEUS_CUSTOM_QUERIES.items():
+        metrics_payloads = []
         current_data = prom.custom_query(query=query)
         prediction = MAD_DICT[metric_name].run(current_data)
+        metrics_payloads.append(prediction)
         for column in COLUMNS_LIST:
             GAUGE_DICT[metric_name].labels(value_type=column).set(prediction[column])
+     # send data to ES
+    try:
+        async for ok, result in async_streaming_bulk(
+            es, doc_generator(metrics_payloads)
+        ):
+            action, result = result.popitem()
+            if not ok:
+                logging.error("failed to {} document {}".format())
+    except (BulkIndexError, ConnectionTimeout) as exception:
+        logging.error("Failed to index data")
+        logging.error(exception)
     return Response(content=generate_latest(REGISTRY).decode('utf-8'), media_type='text; charset=utf-8')
 
 
@@ -128,88 +142,8 @@ async def load_history_data(metric_name, mad: MetricAnomalyDetector):
     except Exception as e:
         logger.warning("fail to load history metrics data!")
 
-
-async def update_metrics(inference_queue):
-    mad_dict = {}
-    for metric_name in metrics_list:  # init models
-        mad = MetricAnomalyDetector(metric_name)
-        await load_history_data(metric_name, mad)
-        mad_dict[metric_name] = mad
-    while True:
-        new_data = await inference_queue.get()
-        starttime = time.time()
-        metrics_payloads = []
-        for metric_name in metrics_list:
-            if len(new_data[metric_name]) == 0:
-                continue
-            json_payload = mad_dict[metric_name].run(new_data[metric_name])  # run MAD
-            if json_payload:
-                metrics_payloads.append(json_payload)
-
-        # send data to ES
-        try:
-            async for ok, result in async_streaming_bulk(
-                es, doc_generator(metrics_payloads)
-            ):
-                action, result = result.popitem()
-                if not ok:
-                    logger.error("failed to {} document {}".format())
-        except (BulkIndexError, ConnectionTimeout) as exception:
-            logger.error("Failed to index data")
-            logger.error(exception)
-
-
 def convert_time(ts):
     return datetime.fromtimestamp(float(ts)).strftime("%Y-%m-%d %H:%M:%S")
 
-
-async def scrape_prometheus_metrics(inference_queue):
-    starttime = time.time()
-    wait_time = (
-        int(starttime) // LOOP_TIME_SECOND * LOOP_TIME_SECOND
-        + LOOP_TIME_SECOND
-        - starttime
-    )
-    await asyncio.sleep(wait_time)  # wait to the start of next minute
-    starttime = time.time()
-    logger.debug(f"wait time : {wait_time}, current time : {convert_time(starttime)}")
-    while True:
-        thistime = time.time()
-        # metrics to collect.
-        cpu_usage = prom.custom_query(
-            query='100 * sum(irate({__name__=~"node_cpu_seconds_total|windows_cpu_time_total",mode!="idle"}[5m])) / (sum(irate({__name__=~"node_cpu_seconds_total|windows_cpu_time_total",mode!="idle"}[5m])) + sum(irate({__name__=~"node_cpu_seconds_total|windows_cpu_time_total",mode="idle"}[5m])))'
-        )
-        memory_usage = prom.custom_query(
-            query="100 * (1 - sum(node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes))"
-        )
-        disk_usage = prom.custom_query(
-            query='(sum(node_filesystem_size_bytes{device!~"rootfs|HarddiskVolume.+"})- sum(node_filesystem_free_bytes{device!~"rootfs|HarddiskVolume.+"})) / sum(node_filesystem_size_bytes{device!~"rootfs|HarddiskVolume.+"}) * 100 '
-        )
-        inference_queue_payload = {
-            "cpu_usage": cpu_usage,
-            "memory_usage": memory_usage,
-            "disk_usage": disk_usage,
-        }
-        await inference_queue.put(inference_queue_payload)
-        await asyncio.sleep(  # to make sure it scrapes every LOOP_TIME seconds.
-            LOOP_TIME_SECOND - ((time.time() - starttime) % LOOP_TIME_SECOND)
-        )
-
-async def run_metrics_server():
-    uvicorn.run(app, port=8000, host='0.0.0.0')
-
-
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    inference_queue = asyncio.Queue(loop=loop)
-    prometheus_scraper_coroutine = scrape_prometheus_metrics(inference_queue)
-    update_metrics_coroutine = update_metrics(inference_queue)
-    uvicorn_server_coroutine = run_metrics_server()
-
-    loop.run_until_complete(
-        asyncio.gather(prometheus_scraper_coroutine, update_metrics_coroutine, uvicorn_server_coroutine)
-    )
-    try:
-        loop.run_forever()
-    finally:
-        loop.close()
+    uvicorn.run(app, port=8000, host='0.0.0.0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pandas==1.2.3
 prometheus_api_client==0.4.2
+prometheus-client==0.12.0
 numpy==1.20.3
 statsmodels==0.12.2
 opni-nats==0.0.0.4

--- a/service-monitor.yaml
+++ b/service-monitor.yaml
@@ -31,3 +31,23 @@ spec:
       opni.io/service: metrics
   endpoints:
   - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: opni-alert-rules
+  namespace: cattle-monitoring-system
+spec:
+  groups:
+  - name: opni-rules
+    rules:
+    - alert: OpniCpuUsageAnomalous
+      expr: cpu_usage{value_type="is_alert"} >= 1
+      annotations:
+        summary: "Anomalous CPU usage in cluster"
+        description: "Opni has calculated an alert score >= 5 for cluster CPU usage"
+    - alert: OpniMemoryUsageAnomalous
+      expr: memory_usage{value_type="is_alert"} >= 1
+      annotations:
+        summary: "Anomalous memory usage in cluster"
+        description: "Opni has calculated an alert score >= 5 for cluster memory usage"

--- a/service-monitor.yaml
+++ b/service-monitor.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opni-metrics-service
+  labels:
+    app.kubernetes.io/name: opni-svc-metrics
+    app.kubernetes.io/part-of: opni
+    opni.io/service: metrics
+spec:
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 8000
+    targetPort: 8000
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: opni-svc-metrics
+    app.kubernetes.io/part-of: opni
+    opni.io/service: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opni-metrics-service
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opni-svc-metrics
+      app.kubernetes.io/part-of: opni
+      opni.io/service: metrics
+  endpoints:
+  - port: metrics


### PR DESCRIPTION
This PR exposes the Arima predictions as prometheus metrics.  Currently we use the data stored in elasticsearch as history for the model, so I have left this in until we move to using Thanos for historical data.